### PR TITLE
rugbyAudit: curses team picker with file context info panel

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,1 +1,3 @@
+export CONDA_DIR="/home/andy/miniconda3"
+source "$CONDA_DIR/etc/profile.d/conda.sh"
 layout conda py312

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -11,14 +11,13 @@
 4.  [Project Structure Standard](#project-structure-standard)\
 5.  [CLI Design Standards](#cli-design-standards)\
 6.  [Environment & Dependency Policy](#environment--dependency-policy)\
-7.  [Framework Guidelines](#framework-guidelines)\
-8.  [Patterns](#patterns)\
-9.  [Error Handling & Logging](#error-handling--logging)\
-10. [Security Standards](#security-standards)\
-11. [Testing Standards](#testing-standards)\
-12. [Performance Guidelines](#performance-guidelines)\
-13. [Refactoring Guidelines](#refactoring-guidelines)\
-14. [Common Principles to Always Follow](#common-principles-to-always-follow)
+7.  [Patterns](#patterns)\
+8.  [Error Handling & Logging](#error-handling--logging)\
+9.  [Security Standards](#security-standards)\
+10. [Testing Standards](#testing-standards)\
+11. [Performance Guidelines](#performance-guidelines)\
+12. [Refactoring Guidelines](#refactoring-guidelines)\
+13. [Common Principles to Always Follow](#common-principles-to-always-follow)
 
 ------------------------------------------------------------------------
 
@@ -158,7 +157,51 @@ Never expose `--dry-run` as the CLI flag. Use `dryRun` only as the internal bool
 
 All projects must use centralized logging from `organiseMyProjects.logUtils`.
 
-Set application context once in root `main.py`, before importing modules that call `getLogger()`:
+### Application context
+
+Each project sets its application context once in the root entry point:
+
+```text
+<projectName>/main.py
+```
+
+Use the project folder name unless there is a deliberate reason to override it:
+
+``` python
+from pathlib import Path
+from organiseMyProjects.logUtils import getLogger, setApplication
+
+thisApplication = Path(__file__).parent.name
+setApplication(thisApplication)
+
+logger = getLogger(includeConsole=False)
+```
+
+`setApplication(thisApplication)` stores the active application name and creates the default log directory:
+
+```text
+~/.local/state/<thisApplication>/
+```
+
+After `setApplication()` has run, do not pass `name` or `logDir` to `getLogger()` for normal application logging. `logUtils` owns that context.
+
+### Helper modules
+
+Helper modules must not import `thisApplication` from `main.py` and must not redefine it.
+
+Use this pattern everywhere outside the entry point:
+
+``` python
+from organiseMyProjects.logUtils import getLogger
+
+logger = getLogger()
+```
+
+This works because the entry point sets the application context before importing modules that call `getLogger()`.
+
+### Entry-point initialisation
+
+Initialise the application context before importing modules that rely on logging. Re-initialise console/dry-run behaviour in `main()` after parsing arguments:
 
 ``` python
 from pathlib import Path
@@ -226,11 +269,14 @@ logger.value("dryRun", config.dryRun)
 Avoid:
 
 ``` python
-logger.info("group: %s", config.groupName)
-logger.doing(f"group...{config.groupName}")
+logger.doing("scanning files")           # → scanning files...
+logger.done("scan complete")             # → ...scan complete
+logger.info("found n items")             # → ...found n items
+logger.value("source dir", path)         # → ...source dir: /path
+logger.action("moving file: src → dest") # → ...[] moving file: src → dest  (when dryRun=True)
 ```
 
-2. Use `logger.info()` for multiple values or narrative messages.
+### The `action()` / dry-run guard pattern
 
 ``` python
 logger.info("opening poll %s/%s: %s", index, totalPolls, pollTitle)
@@ -266,6 +312,18 @@ if not dryRun:
 
 Do not manually build dry-run prefixes or branch log wording by `dryRun`.
 
+### Value Logging Rule
+
+Use `logger.value("name", value)` when logging a single variable.
+
+Do not use:
+- `logger.info("name: %s", value)`
+- f-strings in `doing()` or `done()`
+
+Use `logger.info()` only for:
+- multiple variables
+- narrative messages
+
 ### No fallback logging
 
 External dependencies must fail fast. Never silently replace `logUtils`:
@@ -294,6 +352,51 @@ Do not call `logging.basicConfig()` in application modules.
 from organiseMyProjects.logUtils import drawBox
 
 drawBox("Sync complete\n3 updated, 0 failed", logger=logger)
+```
+
+------------------------------------------------------------------------
+
+### Bash Logging (logUtils.sh)
+
+Bash scripts must source `logUtils.sh` from the `organiseMyProjects` package.
+
+#### Sourcing and initialisation
+
+``` bash
+source "$(python3 -c 'import organiseMyProjects, os; print(os.path.dirname(organiseMyProjects.__file__))')/logUtils.sh"
+setApplication "myScript"
+```
+
+`setApplication "myScript"` writes logs to `~/.local/state/myScript/myScript-<date>.log`.
+
+An optional base directory can be supplied:
+
+``` bash
+setApplication "myScript" "/tmp/logs"
+```
+
+#### Semantic log functions
+
+``` bash
+log_doing "scanning files"           #  →  scanning files...
+log_done  "scan complete"            #  →  ...scan complete
+log_info  "found 5 items"            #  →  ...found 5 items
+log_value "source dir" "/home/andy"  #  →  ...source dir: /home/andy
+log_action "moving file: a → b"      #  →  ...[] moving file: a → b  (when dryRun is non-empty)
+                                     #  →  ...moving file: a → b     (when dryRun is unset/empty)
+log_warn  "file not found"           #  →  WARNING: file not found
+log_error "fatal problem"            #  →  ERROR: fatal problem  (stderr)
+```
+
+#### The `log_action()` / dry-run guard pattern (bash)
+
+``` bash
+dryRun=1  # non-empty = dry-run; unset or empty = live
+
+log_action "moving file: $src → $dest"
+if [[ -z "${dryRun:-}" ]]; then
+    mv "$src" "$dest"
+fi
 ```
 
 ------------------------------------------------------------------------

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -255,12 +255,13 @@ logger.doing(f"attendance export for {group}")
 logger.action("write polls.csv rows: %s", count)
 ```
 
-Use `logger.action()` with the write guard:
+Use `logger.action()` with the write guard. Call `logger.done()` only if the action succeeds:
 
 ``` python
-logger.action(f"moving file: {src} → {dest}")
+logger.action("moving file")
 if not dryRun:
     shutil.move(src, dest)
+    logger.done("moving file")
 ```
 
 Do not manually build dry-run prefixes or branch log wording by `dryRun`.

--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,6 @@ Thumbs.db
 .pytest_cache/
 . coverage
 htmlcov/
+mp4_match_audit.csv
+mp4_match_audit.json
+mp4_match_prompt_audit.csv

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 playwright>=1.50.0
+mutagen

--- a/rugbyAudit.py
+++ b/rugbyAudit.py
@@ -51,7 +51,7 @@ from typing import Iterable
 from mutagen.mp4 import MP4, MP4FreeForm  # type: ignore
 
 
-LOGGER = logging.getLogger("mp4MatchAudit")
+logger = logging.getLogger("mp4MatchAudit")
 SUPPORTED_SUFFIXES = {".mp4", ".m4v", ".mov"}
 FREEFORM_PREFIX = "----:com.apple.iTunes:"
 
@@ -113,7 +113,7 @@ class Mp4TagHelper:
         try:
             mp4File = MP4(str(filePath))
         except Exception as exc:
-            LOGGER.warning("...failed to read tags: %s | %s", filePath, exc)
+            logger.warning("...failed to read tags: %s | %s", filePath, exc)
             return {"_readError": str(exc)}
 
         if mp4File.tags is None:
@@ -243,16 +243,16 @@ class InteractivePrompter:
 
     def playVideo(self, filePath: Path | None) -> None:
         if filePath is None:
-            LOGGER.info("...no file available to play")
+            logger.info("...no file available to play")
             return
         if self.playerPath is None:
-            LOGGER.info("...no supported video player found on PATH")
+            logger.info("...no supported video player found on PATH")
             return
 
         try:
             subprocess.run([self.playerPath, str(filePath)], check=False)
         except Exception as exc:
-            LOGGER.warning("...failed to play video: %s | %s", filePath, exc)
+            logger.warning("...failed to play video: %s | %s", filePath, exc)
 
     @staticmethod
     def _findPlayer() -> str | None:
@@ -351,15 +351,32 @@ def promptForFile(
     defaultTitle = getDefaultText(tags, "title")
     defaultComment = getDefaultText(tags, "comment")
 
-    LOGGER.info("")
-    LOGGER.info("...file: %s", filePath)
+    logger.info("")
+    logger.info("...file: %s", filePath)
     if seasonInfo:
-        LOGGER.info("...season: %s", seasonInfo.seasonLabel)
+        logger.info("...season: %s", seasonInfo.seasonLabel)
     if episode is not None:
-        LOGGER.info("...episode: %s", episode)
+        logger.info("...episode: %s", episode)
+    logger.info("...score: %s", defaultComment or "")
 
-    title = prompter.prompt("title", defaultTitle, filePath=filePath)
-    comment = prompter.prompt("score/comment", defaultComment, filePath=filePath)
+    if defaultComment:
+        logger.info("...skipping file with existing score")
+        title = defaultTitle
+        comment = defaultComment
+    else:
+        homeTeam = prompter.prompt("home team", None, filePath=filePath)
+        if homeTeam == "g":
+            homeTeam = "Gloucester-Hartpury"
+
+        awayTeam = prompter.prompt("away team", None, filePath=filePath)
+        if awayTeam == "g":
+            awayTeam = "Gloucester-Hartpury"
+
+        title = None
+        if homeTeam and awayTeam:
+            title = f"{homeTeam} vs. {awayTeam}"
+
+        comment = prompter.prompt("score/comment", defaultComment, filePath=filePath)
 
     if title is None:
         title = defaultTitle
@@ -392,9 +409,9 @@ def promptForFile(
 
     if writeChanges:
         tagHelper.writeTags(filePath, valuesToWrite)
-        LOGGER.info("...updated tags")
+        logger.info("...updated tags")
     else:
-        LOGGER.info("...dry run values prepared")
+        logger.info("...dry run values prepared")
 
     return {
         "filePath": str(filePath),
@@ -440,7 +457,7 @@ def main(argv: list[str] | None = None) -> int:
 
     inputRoot = Path(args.inputRoot).expanduser().resolve()
     if not inputRoot.exists() or not inputRoot.is_dir():
-        LOGGER.error("Input folder is invalid: %s", inputRoot)
+        logger.error("Input folder is invalid: %s", inputRoot)
         return 2
 
     tagHelper = Mp4TagHelper()
@@ -463,15 +480,15 @@ def main(argv: list[str] | None = None) -> int:
             )
         )
     except UserQuitRequested:
-        LOGGER.info("...user requested quit")
+        logger.info("...user requested quit")
 
     outputCsv = Path(args.outputCsv).expanduser().resolve()
     writeCsv(outputCsv, rows)
 
-    LOGGER.info("")
-    LOGGER.info("...files processed: %s", len(rows))
-    LOGGER.info("...csv report: %s", outputCsv)
-    LOGGER.info("...mode: %s", "write" if args.write else "dry-run")
+    logger.info("")
+    logger.info("...files processed: %s", len(rows))
+    logger.info("...csv report: %s", outputCsv)
+    logger.info("...mode: %s", "write" if args.write else "dry-run")
     return 0
 
 

--- a/rugbyAudit.py
+++ b/rugbyAudit.py
@@ -647,13 +647,39 @@ def getDefaultText(tags: dict[str, object], fieldName: str) -> str | None:
     return str(value)
 
 
+# Trailing noise that occasionally contaminates team names extracted from file
+# titles (e.g. "Bristol Bears SF", "Gloucester-Hartpury Full Match Allianz…").
+# The pattern is anchored to the end of the string and applied repeatedly until
+# no further match is found, so stacked suffixes are stripped cleanly.
+_TEAM_NOISE_RE = re.compile(
+    r"\s+(?:SF|Final|Full\s+Match\b.*|Allianz\b.*)$",
+    re.IGNORECASE,
+)
+
+
+def _cleanTeamName(name: str) -> str:
+    """Strip known trailing noise from a raw team name extracted from a title tag.
+
+    Applies *_TEAM_NOISE_RE* repeatedly until the name stabilises, so that
+    compound suffixes such as "Full Match Allianz Premi-01" are fully removed
+    in one call.
+    """
+    while True:
+        cleaned = _TEAM_NOISE_RE.sub("", name).strip()
+        if cleaned == name:
+            return cleaned
+        name = cleaned
+
+
 def buildKnownTeams(
     inputRoot: Path, tagHelper: Mp4TagHelper, parser: MatchParser
 ) -> list[str]:
     """Pre-scan media files and extract unique team names from existing title tags.
 
     Returns a case-insensitively sorted list of distinct team names found in
-    the ``title`` atoms of all media files under *inputRoot*.
+    the ``title`` atoms of all media files under *inputRoot*.  Known trailing
+    noise (e.g. "SF", "Final", "Full Match …") is stripped before the name is
+    added to the list.
     """
     teamSet: set[str] = set()
     for filePath in iterMediaFiles(inputRoot):
@@ -661,9 +687,9 @@ def buildKnownTeams(
         title = getDefaultText(tags, "title")
         homeTeam, awayTeam = parser.parseTitle(title)
         if homeTeam:
-            teamSet.add(homeTeam.strip())
+            teamSet.add(_cleanTeamName(homeTeam.strip()))
         if awayTeam:
-            teamSet.add(awayTeam.strip())
+            teamSet.add(_cleanTeamName(awayTeam.strip()))
     return sorted(teamSet, key=str.casefold)
 
 

--- a/rugbyAudit.py
+++ b/rugbyAudit.py
@@ -1,0 +1,617 @@
+#!/usr/bin/env python3
+"""Audit MP4 rugby match files by comparing filename-derived data with MP4 tags.
+
+Features
+- scans a folder recursively for MP4/M4V/MOV files
+- extracts match data from filenames where possible
+- reads MP4/iTunes-style tags using mutagen
+- optionally runs ffprobe for container/stream details
+- compares filename-derived values with tag values
+- writes a CSV audit report and a JSON detail report
+
+Suggested filename pattern
+    YYYY-MM-DD - Home Team vs Away Team - 33-31.mp4
+
+Also supports looser variants such as:
+    Gloucester-Hartpury vs Ealing Trailfinders 33-31.mp4
+    2025-01-18 Gloucester-Hartpury v Ealing Trailfinders 33-31.mp4
+
+Dependencies
+    pip install mutagen
+
+Optional
+    ffprobe from FFmpeg on PATH
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import logging
+import os
+import re
+import shutil
+import subprocess
+import sys
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Iterable
+
+from mutagen.mp4 import MP4, MP4FreeForm  # type: ignore
+
+
+LOGGER = logging.getLogger("mp4MatchAudit")
+SUPPORTED_SUFFIXES = {".mp4", ".m4v", ".mov"}
+FREEFORM_PREFIX = "----:com.apple.iTunes:"
+
+# Common MP4/iTunes atoms that are likely useful for sports match cataloguing.
+ATOM_TO_FIELD = {
+    "©nam": "title",
+    "tvsh": "show",
+    "tvsn": "season",
+    "tves": "episode",
+    "©day": "date",
+    "desc": "description",
+    "ldes": "longDescription",
+    "©cmt": "comment",
+    "©grp": "grouping",
+    "©gen": "genre",
+    "aART": "albumArtist",
+    "©ART": "artist",
+    "©alb": "album",
+}
+
+
+@dataclass
+class FilenameMatchData:
+    sourceStem: str
+    matchDate: str | None = None
+    homeTeam: str | None = None
+    awayTeam: str | None = None
+    homeScore: int | None = None
+    awayScore: int | None = None
+    title: str | None = None
+    winner: str | None = None
+    parsePattern: str | None = None
+
+
+@dataclass
+class AuditIssue:
+    field: str
+    severity: str
+    filenameValue: str | None = None
+    tagValue: str | None = None
+    message: str = ""
+
+
+@dataclass
+class FileAudit:
+    filePath: str
+    fileName: str
+    suffix: str
+    sizeBytes: int
+    modifiedUtc: str
+    filenameData: FilenameMatchData
+    tags: dict[str, Any] = field(default_factory=dict)
+    ffprobe: dict[str, Any] | None = None
+    issues: list[AuditIssue] = field(default_factory=list)
+
+    @property
+    def issueCount(self) -> int:
+        return len(self.issues)
+
+    @property
+    def status(self) -> str:
+        return "ok" if not self.issues else "issues"
+
+
+@dataclass
+class Summary:
+    scannedFiles: int = 0
+    parsedFilenames: int = 0
+    filesWithTags: int = 0
+    filesWithIssues: int = 0
+    filesWithoutTags: int = 0
+    filesWithFfprobe: int = 0
+
+
+class MatchFilenameParser:
+    """Extract structured match data from fairly loose sports-video filenames."""
+
+    def __init__(self) -> None:
+        team_expr = r"(?P<home>.+?)\s+(?:vs|v)\s+(?P<away>.+?)"
+        score_expr = r"(?P<homeScore>\d{1,3})\s*[-_]\s*(?P<awayScore>\d{1,3})"
+        date_expr = r"(?P<date>\d{4}-\d{2}-\d{2})"
+
+        self.patterns: list[tuple[str, re.Pattern[str]]] = [
+            (
+                "date-team-score-dashed",
+                re.compile(
+                    rf"^{date_expr}\s*[-–—]\s*{team_expr}\s*[-–—]\s*{score_expr}$",
+                    re.IGNORECASE,
+                ),
+            ),
+            (
+                "date-team-score-spaced",
+                re.compile(
+                    rf"^{date_expr}\s+{team_expr}\s+{score_expr}$",
+                    re.IGNORECASE,
+                ),
+            ),
+            (
+                "team-score",
+                re.compile(rf"^{team_expr}\s+{score_expr}$", re.IGNORECASE),
+            ),
+            (
+                "date-team",
+                re.compile(
+                    rf"^{date_expr}\s*[-–—]?\s*{team_expr}$",
+                    re.IGNORECASE,
+                ),
+            ),
+            (
+                "team-only",
+                re.compile(rf"^{team_expr}$", re.IGNORECASE),
+            ),
+        ]
+
+    def parse(self, filePath: Path) -> FilenameMatchData:
+        stem = self._normaliseStem(filePath.stem)
+        for patternName, pattern in self.patterns:
+            match = pattern.match(stem)
+            if not match:
+                continue
+
+            groups = match.groupdict()
+            homeTeam = self._cleanTeam(groups.get("home"))
+            awayTeam = self._cleanTeam(groups.get("away"))
+            matchDate = self._normaliseDate(groups.get("date"))
+            homeScore = self._toInt(groups.get("homeScore"))
+            awayScore = self._toInt(groups.get("awayScore"))
+
+            winner = None
+            if homeScore is not None and awayScore is not None and homeTeam and awayTeam:
+                if homeScore > awayScore:
+                    winner = homeTeam
+                elif awayScore > homeScore:
+                    winner = awayTeam
+                else:
+                    winner = "draw"
+
+            title = None
+            if homeTeam and awayTeam:
+                title = f"{homeTeam} vs {awayTeam}"
+
+            return FilenameMatchData(
+                sourceStem=filePath.stem,
+                matchDate=matchDate,
+                homeTeam=homeTeam,
+                awayTeam=awayTeam,
+                homeScore=homeScore,
+                awayScore=awayScore,
+                title=title,
+                winner=winner,
+                parsePattern=patternName,
+            )
+
+        return FilenameMatchData(sourceStem=filePath.stem)
+
+    @staticmethod
+    def _normaliseStem(stem: str) -> str:
+        text = stem.replace("_", " ")
+        text = re.sub(r"\s+", " ", text)
+        return text.strip()
+
+    @staticmethod
+    def _cleanTeam(value: str | None) -> str | None:
+        if not value:
+            return None
+        value = re.sub(r"\s+", " ", value).strip(" -–—")
+        return value.strip() or None
+
+    @staticmethod
+    def _toInt(value: str | None) -> int | None:
+        if value is None:
+            return None
+        try:
+            return int(value)
+        except ValueError:
+            return None
+
+    @staticmethod
+    def _normaliseDate(value: str | None) -> str | None:
+        if not value:
+            return None
+        try:
+            return datetime.strptime(value, "%Y-%m-%d").date().isoformat()
+        except ValueError:
+            return value
+
+
+class Mp4TagReader:
+    def readTags(self, filePath: Path) -> dict[str, Any]:
+        try:
+            mp4File = MP4(str(filePath))
+        except Exception as exc:  # pragma: no cover - depends on file content
+            LOGGER.warning("...failed to read mp4 tags: %s | %s", filePath, exc)
+            return {"_readError": str(exc)}
+
+        if mp4File.tags is None:
+            return {}
+
+        result: dict[str, Any] = {}
+        for key, rawValue in mp4File.tags.items():
+            fieldName = ATOM_TO_FIELD.get(key, self._mapFreeformFieldName(key))
+            result[fieldName] = self._normaliseTagValue(rawValue)
+
+        return result
+
+    @staticmethod
+    def _mapFreeformFieldName(key: str) -> str:
+        if key.startswith(FREEFORM_PREFIX):
+            return key[len(FREEFORM_PREFIX):]
+        return key
+
+    def _normaliseTagValue(self, value: Any) -> Any:
+        if isinstance(value, list):
+            if len(value) == 1:
+                return self._normaliseSingleValue(value[0])
+            return [self._normaliseSingleValue(item) for item in value]
+        return self._normaliseSingleValue(value)
+
+    def _normaliseSingleValue(self, value: Any) -> Any:
+        if isinstance(value, MP4FreeForm):
+            return self._decodeBytes(bytes(value))
+        if isinstance(value, bytes):
+            return self._decodeBytes(value)
+        if isinstance(value, tuple):
+            return [self._normaliseSingleValue(item) for item in value]
+        return value
+
+    @staticmethod
+    def _decodeBytes(value: bytes) -> str:
+        for encoding in ("utf-8", "utf-16", "latin-1"):
+            try:
+                return value.decode(encoding).strip("\x00")
+            except UnicodeDecodeError:
+                continue
+        return value.hex()
+
+
+class FfprobeReader:
+    def __init__(self, enabled: bool = True) -> None:
+        self.enabled = enabled
+        self.ffprobePath = shutil.which("ffprobe") if enabled else None
+
+    def isAvailable(self) -> bool:
+        return bool(self.ffprobePath)
+
+    def read(self, filePath: Path) -> dict[str, Any] | None:
+        if not self.ffprobePath:
+            return None
+
+        command = [
+            self.ffprobePath,
+            "-v",
+            "error",
+            "-print_format",
+            "json",
+            "-show_format",
+            "-show_streams",
+            str(filePath),
+        ]
+
+        try:
+            completed = subprocess.run(
+                command,
+                check=True,
+                capture_output=True,
+                text=True,
+            )
+            payload = json.loads(completed.stdout)
+            return self._trimPayload(payload)
+        except Exception as exc:  # pragma: no cover - depends on runtime tools
+            LOGGER.warning("...ffprobe failed: %s | %s", filePath, exc)
+            return {"_readError": str(exc)}
+
+    @staticmethod
+    def _trimPayload(payload: dict[str, Any]) -> dict[str, Any]:
+        formatSection = payload.get("format", {})
+        streams = payload.get("streams", [])
+        videoStream = next((stream for stream in streams if stream.get("codec_type") == "video"), {})
+        audioStream = next((stream for stream in streams if stream.get("codec_type") == "audio"), {})
+
+        return {
+            "formatName": formatSection.get("format_name"),
+            "duration": formatSection.get("duration"),
+            "bitRate": formatSection.get("bit_rate"),
+            "probeTags": formatSection.get("tags", {}),
+            "video": {
+                "codec": videoStream.get("codec_name"),
+                "width": videoStream.get("width"),
+                "height": videoStream.get("height"),
+                "avgFrameRate": videoStream.get("avg_frame_rate"),
+            },
+            "audio": {
+                "codec": audioStream.get("codec_name"),
+                "channels": audioStream.get("channels"),
+                "sampleRate": audioStream.get("sample_rate"),
+            },
+        }
+
+
+class AuditEngine:
+    def __init__(self, includeFfprobe: bool) -> None:
+        self.filenameParser = MatchFilenameParser()
+        self.tagReader = Mp4TagReader()
+        self.ffprobeReader = FfprobeReader(enabled=includeFfprobe)
+
+    def auditFiles(self, inputRoot: Path) -> tuple[list[FileAudit], Summary]:
+        audits: list[FileAudit] = []
+        summary = Summary()
+
+        for filePath in self._iterMediaFiles(inputRoot):
+            summary.scannedFiles += 1
+            audits.append(self._auditSingleFile(filePath, summary))
+
+        summary.filesWithIssues = sum(1 for audit in audits if audit.issues)
+        return audits, summary
+
+    def _auditSingleFile(self, filePath: Path, summary: Summary) -> FileAudit:
+        stat = filePath.stat()
+        filenameData = self.filenameParser.parse(filePath)
+        if filenameData.parsePattern:
+            summary.parsedFilenames += 1
+
+        tags = self.tagReader.readTags(filePath)
+        if tags and "_readError" not in tags:
+            summary.filesWithTags += 1
+        else:
+            summary.filesWithoutTags += 1
+
+        ffprobeData = self.ffprobeReader.read(filePath)
+        if ffprobeData and "_readError" not in ffprobeData:
+            summary.filesWithFfprobe += 1
+
+        audit = FileAudit(
+            filePath=str(filePath),
+            fileName=filePath.name,
+            suffix=filePath.suffix.lower(),
+            sizeBytes=stat.st_size,
+            modifiedUtc=datetime.fromtimestamp(stat.st_mtime, tz=timezone.utc).isoformat(),
+            filenameData=filenameData,
+            tags=tags,
+            ffprobe=ffprobeData,
+        )
+
+        audit.issues.extend(self._compareFilenameToTags(filenameData, tags))
+        return audit
+
+    @staticmethod
+    def _iterMediaFiles(inputRoot: Path) -> Iterable[Path]:
+        for filePath in sorted(inputRoot.rglob("*")):
+            if filePath.is_file() and filePath.suffix.lower() in SUPPORTED_SUFFIXES:
+                yield filePath
+
+    def _compareFilenameToTags(
+        self,
+        filenameData: FilenameMatchData,
+        tags: dict[str, Any],
+    ) -> list[AuditIssue]:
+        issues: list[AuditIssue] = []
+
+        checks = [
+            ("title", filenameData.title, self._getTagText(tags, "title")),
+            ("date", filenameData.matchDate, self._getTagText(tags, "date")),
+            ("homeTeam", filenameData.homeTeam, self._getTagText(tags, "homeTeam")),
+            ("awayTeam", filenameData.awayTeam, self._getTagText(tags, "awayTeam")),
+            ("homeScore", self._toText(filenameData.homeScore), self._getTagText(tags, "homeScore")),
+            ("awayScore", self._toText(filenameData.awayScore), self._getTagText(tags, "awayScore")),
+            ("winner", filenameData.winner, self._getTagText(tags, "winner")),
+        ]
+
+        for fieldName, filenameValue, tagValue in checks:
+            if filenameValue and not tagValue:
+                issues.append(
+                    AuditIssue(
+                        field=fieldName,
+                        severity="warning",
+                        filenameValue=filenameValue,
+                        tagValue=tagValue,
+                        message="value found in filename but missing from tags",
+                    )
+                )
+            elif filenameValue and tagValue and not self._equivalent(filenameValue, tagValue):
+                issues.append(
+                    AuditIssue(
+                        field=fieldName,
+                        severity="error",
+                        filenameValue=filenameValue,
+                        tagValue=tagValue,
+                        message="filename value and tag value differ",
+                    )
+                )
+
+        if not filenameData.parsePattern:
+            issues.append(
+                AuditIssue(
+                    field="filename",
+                    severity="warning",
+                    message="filename did not match a known match pattern",
+                )
+            )
+
+        if tags.get("_readError"):
+            issues.append(
+                AuditIssue(
+                    field="tags",
+                    severity="error",
+                    tagValue=str(tags.get("_readError")),
+                    message="failed to read tags",
+                )
+            )
+
+        return issues
+
+    @staticmethod
+    def _getTagText(tags: dict[str, Any], fieldName: str) -> str | None:
+        value = tags.get(fieldName)
+        if value is None:
+            return None
+        if isinstance(value, list):
+            return " | ".join(str(item) for item in value)
+        return str(value)
+
+    @staticmethod
+    def _toText(value: Any) -> str | None:
+        return None if value is None else str(value)
+
+    @staticmethod
+    def _equivalent(left: str, right: str) -> bool:
+        return AuditEngine._normaliseCompare(left) == AuditEngine._normaliseCompare(right)
+
+    @staticmethod
+    def _normaliseCompare(value: str) -> str:
+        value = value.strip().lower()
+        value = value.replace("–", "-").replace("—", "-")
+        value = re.sub(r"\s+", " ", value)
+        return value
+
+
+def configureLogging(verbose: bool) -> None:
+    level = logging.DEBUG if verbose else logging.INFO
+    logging.basicConfig(level=level, format="%(message)s")
+
+
+def parseArgs(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Audit MP4 match files and tags.")
+    parser.add_argument("inputRoot", help="root folder to scan")
+    parser.add_argument(
+        "--outputCsv",
+        default="mp4_match_audit.csv",
+        help="path to CSV report",
+    )
+    parser.add_argument(
+        "--outputJson",
+        default="mp4_match_audit.json",
+        help="path to JSON detail report",
+    )
+    parser.add_argument(
+        "--noFfprobe",
+        action="store_true",
+        help="skip ffprobe even if it is installed",
+    )
+    parser.add_argument(
+        "--verbose",
+        action="store_true",
+        help="enable debug logging",
+    )
+    return parser.parse_args(argv)
+
+
+def writeCsv(outputPath: Path, audits: list[FileAudit]) -> None:
+    fieldNames = [
+        "filePath",
+        "fileName",
+        "status",
+        "issueCount",
+        "parsePattern",
+        "matchDate",
+        "homeTeam",
+        "awayTeam",
+        "homeScore",
+        "awayScore",
+        "winner",
+        "tagTitle",
+        "tagDate",
+        "tagHomeTeam",
+        "tagAwayTeam",
+        "tagHomeScore",
+        "tagAwayScore",
+        "tagWinner",
+        "issueSummary",
+    ]
+
+    with outputPath.open("w", newline="", encoding="utf-8") as handle:
+        writer = csv.DictWriter(handle, fieldnames=fieldNames)
+        writer.writeheader()
+        for audit in audits:
+            writer.writerow(
+                {
+                    "filePath": audit.filePath,
+                    "fileName": audit.fileName,
+                    "status": audit.status,
+                    "issueCount": audit.issueCount,
+                    "parsePattern": audit.filenameData.parsePattern,
+                    "matchDate": audit.filenameData.matchDate,
+                    "homeTeam": audit.filenameData.homeTeam,
+                    "awayTeam": audit.filenameData.awayTeam,
+                    "homeScore": audit.filenameData.homeScore,
+                    "awayScore": audit.filenameData.awayScore,
+                    "winner": audit.filenameData.winner,
+                    "tagTitle": audit.tags.get("title"),
+                    "tagDate": audit.tags.get("date"),
+                    "tagHomeTeam": audit.tags.get("homeTeam"),
+                    "tagAwayTeam": audit.tags.get("awayTeam"),
+                    "tagHomeScore": audit.tags.get("homeScore"),
+                    "tagAwayScore": audit.tags.get("awayScore"),
+                    "tagWinner": audit.tags.get("winner"),
+                    "issueSummary": " | ".join(issue.message for issue in audit.issues),
+                }
+            )
+
+
+def writeJson(outputPath: Path, audits: list[FileAudit], summary: Summary) -> None:
+    payload = {
+        "generatedUtc": datetime.now(tz=timezone.utc).isoformat(),
+        "summary": asdict(summary),
+        "files": [
+            {
+                **asdict(audit),
+                "status": audit.status,
+                "issueCount": audit.issueCount,
+            }
+            for audit in audits
+        ],
+    }
+
+    with outputPath.open("w", encoding="utf-8") as handle:
+        json.dump(payload, handle, indent=2, ensure_ascii=False)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parseArgs(argv or sys.argv[1:])
+    configureLogging(args.verbose)
+
+    inputRoot = Path(args.inputRoot).expanduser().resolve()
+    outputCsv = Path(args.outputCsv).expanduser().resolve()
+    outputJson = Path(args.outputJson).expanduser().resolve()
+
+    if not inputRoot.exists():
+        LOGGER.error("Input folder does not exist: %s", inputRoot)
+        return 2
+
+    if not inputRoot.is_dir():
+        LOGGER.error("Input path is not a directory: %s", inputRoot)
+        return 2
+
+    engine = AuditEngine(includeFfprobe=not args.noFfprobe)
+    audits, summary = engine.auditFiles(inputRoot)
+
+    writeCsv(outputCsv, audits)
+    writeJson(outputJson, audits, summary)
+
+    LOGGER.info("...scanned files: %s", summary.scannedFiles)
+    LOGGER.info("...parsed filenames: %s", summary.parsedFilenames)
+    LOGGER.info("...files with tags: %s", summary.filesWithTags)
+    LOGGER.info("...files with issues: %s", summary.filesWithIssues)
+    LOGGER.info("...csv report: %s", outputCsv)
+    LOGGER.info("...json report: %s", outputJson)
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/rugbyAudit.py
+++ b/rugbyAudit.py
@@ -1,43 +1,52 @@
 #!/usr/bin/env python3
-"""Audit MP4 rugby match files by comparing filename-derived data with MP4 tags.
+"""Interactive audit and tagging tool for rugby match MP4 files.
 
-Features
-- scans a folder recursively for MP4/M4V/MOV files
-- extracts match data from filenames where possible
-- reads MP4/iTunes-style tags using mutagen
-- optionally runs ffprobe for container/stream details
-- compares filename-derived values with tag values
-- writes a CSV audit report and a JSON detail report
+Purpose
+- scan a folder recursively for MP4/M4V/MOV files
+- read existing MP4 tags
+- show current title/comment values as defaults
+- prompt the user to confirm or replace title and score
+- derive teams from title
+- derive season and episode from folder/year and match ordering
+- optionally write updated metadata back to files
+- write a CSV audit report
 
-Suggested filename pattern
-    YYYY-MM-DD - Home Team vs Away Team - 33-31.mp4
+User interaction rule
+- pressing Enter accepts the shown default
+- entering q quits the session
+- entering p plays the current video so you can inspect it
+- if there is no default, pressing Enter leaves the field blank
 
-Also supports looser variants such as:
-    Gloucester-Hartpury vs Ealing Trailfinders 33-31.mp4
-    2025-01-18 Gloucester-Hartpury v Ealing Trailfinders 33-31.mp4
+Recommended title format
+    Home Team vs Away Team
+or
+    Home Team v Away Team
+
+Recommended comment format
+    33-31
+
+Notes
+- folder year is treated as the season start year
+  example: folder 2024 => seasonLabel 2024/25
+- episode is assigned by ordering matches within a season folder
+  after sorting by file path
 
 Dependencies
     pip install mutagen
-
-Optional
-    ffprobe from FFmpeg on PATH
 """
 
 from __future__ import annotations
 
 import argparse
 import csv
-import json
 import logging
-import os
 import re
 import shutil
 import subprocess
 import sys
-from dataclasses import asdict, dataclass, field
-from datetime import datetime, timezone
+from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Iterable
+from typing import Iterable
 
 from mutagen.mp4 import MP4, MP4FreeForm  # type: ignore
 
@@ -46,7 +55,6 @@ LOGGER = logging.getLogger("mp4MatchAudit")
 SUPPORTED_SUFFIXES = {".mp4", ".m4v", ".mov"}
 FREEFORM_PREFIX = "----:com.apple.iTunes:"
 
-# Common MP4/iTunes atoms that are likely useful for sports match cataloguing.
 ATOM_TO_FIELD = {
     "©nam": "title",
     "tvsh": "show",
@@ -63,190 +71,77 @@ ATOM_TO_FIELD = {
     "©alb": "album",
 }
 
-
-@dataclass
-class FilenameMatchData:
-    sourceStem: str
-    matchDate: str | None = None
-    homeTeam: str | None = None
-    awayTeam: str | None = None
-    homeScore: int | None = None
-    awayScore: int | None = None
-    title: str | None = None
-    winner: str | None = None
-    parsePattern: str | None = None
-
-
-@dataclass
-class AuditIssue:
-    field: str
-    severity: str
-    filenameValue: str | None = None
-    tagValue: str | None = None
-    message: str = ""
+FIELD_TO_ATOM = {
+    "title": "©nam",
+    "show": "tvsh",
+    "season": "tvsn",
+    "episode": "tves",
+    "date": "©day",
+    "description": "desc",
+    "comment": "©cmt",
+    "grouping": "©grp",
+    "genre": "©gen",
+    "albumArtist": "aART",
+    "artist": "©ART",
+    "album": "©alb",
+}
 
 
 @dataclass
-class FileAudit:
-    filePath: str
-    fileName: str
-    suffix: str
-    sizeBytes: int
-    modifiedUtc: str
-    filenameData: FilenameMatchData
-    tags: dict[str, Any] = field(default_factory=dict)
-    ffprobe: dict[str, Any] | None = None
-    issues: list[AuditIssue] = field(default_factory=list)
-
-    @property
-    def issueCount(self) -> int:
-        return len(self.issues)
-
-    @property
-    def status(self) -> str:
-        return "ok" if not self.issues else "issues"
+class SeasonInfo:
+    seasonKey: int
+    seasonLabel: str
+    seasonStartYear: int
+    seasonEndYear: int
 
 
 @dataclass
-class Summary:
-    scannedFiles: int = 0
-    parsedFilenames: int = 0
-    filesWithTags: int = 0
-    filesWithIssues: int = 0
-    filesWithoutTags: int = 0
-    filesWithFfprobe: int = 0
+class MatchInfo:
+    title: str | None
+    comment: str | None
+    homeTeam: str | None
+    awayTeam: str | None
+    homeScore: int | None
+    awayScore: int | None
+    winner: str | None
+    seasonInfo: SeasonInfo | None
+    episode: int | None
 
 
-class MatchFilenameParser:
-    """Extract structured match data from fairly loose sports-video filenames."""
-
-    def __init__(self) -> None:
-        team_expr = r"(?P<home>.+?)\s+(?:vs|v)\s+(?P<away>.+?)"
-        score_expr = r"(?P<homeScore>\d{1,3})\s*[-_]\s*(?P<awayScore>\d{1,3})"
-        date_expr = r"(?P<date>\d{4}-\d{2}-\d{2})"
-
-        self.patterns: list[tuple[str, re.Pattern[str]]] = [
-            (
-                "date-team-score-dashed",
-                re.compile(
-                    rf"^{date_expr}\s*[-–—]\s*{team_expr}\s*[-–—]\s*{score_expr}$",
-                    re.IGNORECASE,
-                ),
-            ),
-            (
-                "date-team-score-spaced",
-                re.compile(
-                    rf"^{date_expr}\s+{team_expr}\s+{score_expr}$",
-                    re.IGNORECASE,
-                ),
-            ),
-            (
-                "team-score",
-                re.compile(rf"^{team_expr}\s+{score_expr}$", re.IGNORECASE),
-            ),
-            (
-                "date-team",
-                re.compile(
-                    rf"^{date_expr}\s*[-–—]?\s*{team_expr}$",
-                    re.IGNORECASE,
-                ),
-            ),
-            (
-                "team-only",
-                re.compile(rf"^{team_expr}$", re.IGNORECASE),
-            ),
-        ]
-
-    def parse(self, filePath: Path) -> FilenameMatchData:
-        stem = self._normaliseStem(filePath.stem)
-        for patternName, pattern in self.patterns:
-            match = pattern.match(stem)
-            if not match:
-                continue
-
-            groups = match.groupdict()
-            homeTeam = self._cleanTeam(groups.get("home"))
-            awayTeam = self._cleanTeam(groups.get("away"))
-            matchDate = self._normaliseDate(groups.get("date"))
-            homeScore = self._toInt(groups.get("homeScore"))
-            awayScore = self._toInt(groups.get("awayScore"))
-
-            winner = None
-            if homeScore is not None and awayScore is not None and homeTeam and awayTeam:
-                if homeScore > awayScore:
-                    winner = homeTeam
-                elif awayScore > homeScore:
-                    winner = awayTeam
-                else:
-                    winner = "draw"
-
-            title = None
-            if homeTeam and awayTeam:
-                title = f"{homeTeam} vs {awayTeam}"
-
-            return FilenameMatchData(
-                sourceStem=filePath.stem,
-                matchDate=matchDate,
-                homeTeam=homeTeam,
-                awayTeam=awayTeam,
-                homeScore=homeScore,
-                awayScore=awayScore,
-                title=title,
-                winner=winner,
-                parsePattern=patternName,
-            )
-
-        return FilenameMatchData(sourceStem=filePath.stem)
-
-    @staticmethod
-    def _normaliseStem(stem: str) -> str:
-        text = stem.replace("_", " ")
-        text = re.sub(r"\s+", " ", text)
-        return text.strip()
-
-    @staticmethod
-    def _cleanTeam(value: str | None) -> str | None:
-        if not value:
-            return None
-        value = re.sub(r"\s+", " ", value).strip(" -–—")
-        return value.strip() or None
-
-    @staticmethod
-    def _toInt(value: str | None) -> int | None:
-        if value is None:
-            return None
-        try:
-            return int(value)
-        except ValueError:
-            return None
-
-    @staticmethod
-    def _normaliseDate(value: str | None) -> str | None:
-        if not value:
-            return None
-        try:
-            return datetime.strptime(value, "%Y-%m-%d").date().isoformat()
-        except ValueError:
-            return value
-
-
-class Mp4TagReader:
-    def readTags(self, filePath: Path) -> dict[str, Any]:
+class Mp4TagHelper:
+    def readTags(self, filePath: Path) -> dict[str, object]:
         try:
             mp4File = MP4(str(filePath))
-        except Exception as exc:  # pragma: no cover - depends on file content
-            LOGGER.warning("...failed to read mp4 tags: %s | %s", filePath, exc)
+        except Exception as exc:
+            LOGGER.warning("...failed to read tags: %s | %s", filePath, exc)
             return {"_readError": str(exc)}
 
         if mp4File.tags is None:
             return {}
 
-        result: dict[str, Any] = {}
+        result: dict[str, object] = {}
         for key, rawValue in mp4File.tags.items():
             fieldName = ATOM_TO_FIELD.get(key, self._mapFreeformFieldName(key))
             result[fieldName] = self._normaliseTagValue(rawValue)
-
         return result
+
+    def writeTags(self, filePath: Path, values: dict[str, object]) -> None:
+        mp4File = MP4(str(filePath))
+        if mp4File.tags is None:
+            mp4File.add_tags()
+
+        for fieldName, value in values.items():
+            if value is None or value == "":
+                continue
+
+            atom = FIELD_TO_ATOM.get(fieldName)
+            if atom:
+                mp4File.tags[atom] = self._encodeStandardValue(fieldName, value)
+            else:
+                freeformKey = f"{FREEFORM_PREFIX}{fieldName}"
+                mp4File.tags[freeformKey] = [MP4FreeForm(str(value).encode("utf-8"))]
+
+        mp4File.save()
 
     @staticmethod
     def _mapFreeformFieldName(key: str) -> str:
@@ -254,331 +149,289 @@ class Mp4TagReader:
             return key[len(FREEFORM_PREFIX):]
         return key
 
-    def _normaliseTagValue(self, value: Any) -> Any:
+    def _normaliseTagValue(self, value: object) -> object:
         if isinstance(value, list):
             if len(value) == 1:
                 return self._normaliseSingleValue(value[0])
             return [self._normaliseSingleValue(item) for item in value]
         return self._normaliseSingleValue(value)
 
-    def _normaliseSingleValue(self, value: Any) -> Any:
+    def _normaliseSingleValue(self, value: object) -> object:
         if isinstance(value, MP4FreeForm):
-            return self._decodeBytes(bytes(value))
+            return bytes(value).decode("utf-8", errors="replace").strip("\x00")
         if isinstance(value, bytes):
-            return self._decodeBytes(value)
+            return value.decode("utf-8", errors="replace").strip("\x00")
         if isinstance(value, tuple):
             return [self._normaliseSingleValue(item) for item in value]
         return value
 
     @staticmethod
-    def _decodeBytes(value: bytes) -> str:
-        for encoding in ("utf-8", "utf-16", "latin-1"):
-            try:
-                return value.decode(encoding).strip("\x00")
-            except UnicodeDecodeError:
-                continue
-        return value.hex()
+    def _encodeStandardValue(fieldName: str, value: object) -> list[object]:
+        if fieldName in {"season", "episode"}:
+            return [int(value)]
+        return [str(value)]
 
 
-class FfprobeReader:
-    def __init__(self, enabled: bool = True) -> None:
-        self.enabled = enabled
-        self.ffprobePath = shutil.which("ffprobe") if enabled else None
+class MatchParser:
+    TITLE_PATTERN = re.compile(r"^(?P<home>.+?)\s+(?:vs\.?|v)\s+(?P<away>.+?)$", re.IGNORECASE)
+    SCORE_PATTERN = re.compile(r"^(?P<home>\d{1,3})\s*[-:]\s*(?P<away>\d{1,3})$")
 
-    def isAvailable(self) -> bool:
-        return bool(self.ffprobePath)
+    def parseTitle(self, title: str | None) -> tuple[str | None, str | None]:
+        if not title:
+            return None, None
+        cleaned = self._cleanTitle(title)
+        match = self.TITLE_PATTERN.match(cleaned)
+        if not match:
+            return None, None
+        return match.group("home").strip(), match.group("away").strip()
 
-    def read(self, filePath: Path) -> dict[str, Any] | None:
-        if not self.ffprobePath:
+    def parseScore(self, scoreText: str | None) -> tuple[int | None, int | None]:
+        if not scoreText:
+            return None, None
+        match = self.SCORE_PATTERN.match(scoreText.strip())
+        if not match:
+            return None, None
+        return int(match.group("home")), int(match.group("away"))
+
+    def determineWinner(
+        self,
+        homeTeam: str | None,
+        awayTeam: str | None,
+        homeScore: int | None,
+        awayScore: int | None,
+    ) -> str | None:
+        if homeScore is None or awayScore is None:
             return None
+        if homeScore > awayScore:
+            return homeTeam
+        if awayScore > homeScore:
+            return awayTeam
+        return "draw"
 
-        command = [
-            self.ffprobePath,
-            "-v",
-            "error",
-            "-print_format",
-            "json",
-            "-show_format",
-            "-show_streams",
-            str(filePath),
-        ]
+    @staticmethod
+    def _cleanTitle(title: str) -> str:
+        text = title.strip()
+        text = re.sub(r"\s+", " ", text)
+        return text
+
+
+class InteractivePrompter:
+    def __init__(self) -> None:
+        self.playerPath = self._findPlayer()
+
+    def prompt(self, label: str, default: str | None = None, filePath: Path | None = None) -> str | None:
+        while True:
+            if default is None:
+                promptText = f"{label} [enter=blank, q=quit, p=play]: "
+            else:
+                promptText = f"{label} [{default}] (enter=accept, q=quit, p=play): "
+
+            response = input(promptText)
+            stripped = response.strip().lower()
+
+            if stripped == "q":
+                raise UserQuitRequested()
+
+            if stripped == "p":
+                self.playVideo(filePath)
+                continue
+
+            if response == "":
+                return default
+
+            return response.strip()
+
+    def playVideo(self, filePath: Path | None) -> None:
+        if filePath is None:
+            LOGGER.info("...no file available to play")
+            return
+        if self.playerPath is None:
+            LOGGER.info("...no supported video player found on PATH")
+            return
 
         try:
-            completed = subprocess.run(
-                command,
-                check=True,
-                capture_output=True,
-                text=True,
-            )
-            payload = json.loads(completed.stdout)
-            return self._trimPayload(payload)
-        except Exception as exc:  # pragma: no cover - depends on runtime tools
-            LOGGER.warning("...ffprobe failed: %s | %s", filePath, exc)
-            return {"_readError": str(exc)}
+            subprocess.run([self.playerPath, str(filePath)], check=False)
+        except Exception as exc:
+            LOGGER.warning("...failed to play video: %s | %s", filePath, exc)
 
     @staticmethod
-    def _trimPayload(payload: dict[str, Any]) -> dict[str, Any]:
-        formatSection = payload.get("format", {})
-        streams = payload.get("streams", [])
-        videoStream = next((stream for stream in streams if stream.get("codec_type") == "video"), {})
-        audioStream = next((stream for stream in streams if stream.get("codec_type") == "audio"), {})
-
-        return {
-            "formatName": formatSection.get("format_name"),
-            "duration": formatSection.get("duration"),
-            "bitRate": formatSection.get("bit_rate"),
-            "probeTags": formatSection.get("tags", {}),
-            "video": {
-                "codec": videoStream.get("codec_name"),
-                "width": videoStream.get("width"),
-                "height": videoStream.get("height"),
-                "avgFrameRate": videoStream.get("avg_frame_rate"),
-            },
-            "audio": {
-                "codec": audioStream.get("codec_name"),
-                "channels": audioStream.get("channels"),
-                "sampleRate": audioStream.get("sample_rate"),
-            },
-        }
+    def _findPlayer() -> str | None:
+        for candidate in ("mpv", "vlc", "xdg-open"):
+            path = shutil.which(candidate)
+            if path:
+                return path
+        return None
 
 
-class AuditEngine:
-    def __init__(self, includeFfprobe: bool) -> None:
-        self.filenameParser = MatchFilenameParser()
-        self.tagReader = Mp4TagReader()
-        self.ffprobeReader = FfprobeReader(enabled=includeFfprobe)
-
-    def auditFiles(self, inputRoot: Path) -> tuple[list[FileAudit], Summary]:
-        audits: list[FileAudit] = []
-        summary = Summary()
-
-        for filePath in self._iterMediaFiles(inputRoot):
-            summary.scannedFiles += 1
-            audits.append(self._auditSingleFile(filePath, summary))
-
-        summary.filesWithIssues = sum(1 for audit in audits if audit.issues)
-        return audits, summary
-
-    def _auditSingleFile(self, filePath: Path, summary: Summary) -> FileAudit:
-        stat = filePath.stat()
-        filenameData = self.filenameParser.parse(filePath)
-        if filenameData.parsePattern:
-            summary.parsedFilenames += 1
-
-        tags = self.tagReader.readTags(filePath)
-        if tags and "_readError" not in tags:
-            summary.filesWithTags += 1
-        else:
-            summary.filesWithoutTags += 1
-
-        ffprobeData = self.ffprobeReader.read(filePath)
-        if ffprobeData and "_readError" not in ffprobeData:
-            summary.filesWithFfprobe += 1
-
-        audit = FileAudit(
-            filePath=str(filePath),
-            fileName=filePath.name,
-            suffix=filePath.suffix.lower(),
-            sizeBytes=stat.st_size,
-            modifiedUtc=datetime.fromtimestamp(stat.st_mtime, tz=timezone.utc).isoformat(),
-            filenameData=filenameData,
-            tags=tags,
-            ffprobe=ffprobeData,
-        )
-
-        audit.issues.extend(self._compareFilenameToTags(filenameData, tags))
-        return audit
-
-    @staticmethod
-    def _iterMediaFiles(inputRoot: Path) -> Iterable[Path]:
-        for filePath in sorted(inputRoot.rglob("*")):
-            if filePath.is_file() and filePath.suffix.lower() in SUPPORTED_SUFFIXES:
-                yield filePath
-
-    def _compareFilenameToTags(
-        self,
-        filenameData: FilenameMatchData,
-        tags: dict[str, Any],
-    ) -> list[AuditIssue]:
-        issues: list[AuditIssue] = []
-
-        checks = [
-            ("title", filenameData.title, self._getTagText(tags, "title")),
-            ("date", filenameData.matchDate, self._getTagText(tags, "date")),
-            ("homeTeam", filenameData.homeTeam, self._getTagText(tags, "homeTeam")),
-            ("awayTeam", filenameData.awayTeam, self._getTagText(tags, "awayTeam")),
-            ("homeScore", self._toText(filenameData.homeScore), self._getTagText(tags, "homeScore")),
-            ("awayScore", self._toText(filenameData.awayScore), self._getTagText(tags, "awayScore")),
-            ("winner", filenameData.winner, self._getTagText(tags, "winner")),
-        ]
-
-        for fieldName, filenameValue, tagValue in checks:
-            if filenameValue and not tagValue:
-                issues.append(
-                    AuditIssue(
-                        field=fieldName,
-                        severity="warning",
-                        filenameValue=filenameValue,
-                        tagValue=tagValue,
-                        message="value found in filename but missing from tags",
-                    )
-                )
-            elif filenameValue and tagValue and not self._equivalent(filenameValue, tagValue):
-                issues.append(
-                    AuditIssue(
-                        field=fieldName,
-                        severity="error",
-                        filenameValue=filenameValue,
-                        tagValue=tagValue,
-                        message="filename value and tag value differ",
-                    )
-                )
-
-        if not filenameData.parsePattern:
-            issues.append(
-                AuditIssue(
-                    field="filename",
-                    severity="warning",
-                    message="filename did not match a known match pattern",
-                )
-            )
-
-        if tags.get("_readError"):
-            issues.append(
-                AuditIssue(
-                    field="tags",
-                    severity="error",
-                    tagValue=str(tags.get("_readError")),
-                    message="failed to read tags",
-                )
-            )
-
-        return issues
-
-    @staticmethod
-    def _getTagText(tags: dict[str, Any], fieldName: str) -> str | None:
-        value = tags.get(fieldName)
-        if value is None:
-            return None
-        if isinstance(value, list):
-            return " | ".join(str(item) for item in value)
-        return str(value)
-
-    @staticmethod
-    def _toText(value: Any) -> str | None:
-        return None if value is None else str(value)
-
-    @staticmethod
-    def _equivalent(left: str, right: str) -> bool:
-        return AuditEngine._normaliseCompare(left) == AuditEngine._normaliseCompare(right)
-
-    @staticmethod
-    def _normaliseCompare(value: str) -> str:
-        value = value.strip().lower()
-        value = value.replace("–", "-").replace("—", "-")
-        value = re.sub(r"\s+", " ", value)
-        return value
+class UserQuitRequested(Exception):
+    """Raised when the user chooses to quit the interactive session."""
 
 
 def configureLogging(verbose: bool) -> None:
-    level = logging.DEBUG if verbose else logging.INFO
-    logging.basicConfig(level=level, format="%(message)s")
+    logging.basicConfig(level=logging.DEBUG if verbose else logging.INFO, format="%(message)s")
 
 
 def parseArgs(argv: list[str]) -> argparse.Namespace:
-    parser = argparse.ArgumentParser(description="Audit MP4 match files and tags.")
+    parser = argparse.ArgumentParser(description="Interactively audit and tag rugby match videos.")
     parser.add_argument("inputRoot", help="root folder to scan")
-    parser.add_argument(
-        "--outputCsv",
-        default="mp4_match_audit.csv",
-        help="path to CSV report",
-    )
-    parser.add_argument(
-        "--outputJson",
-        default="mp4_match_audit.json",
-        help="path to JSON detail report",
-    )
-    parser.add_argument(
-        "--noFfprobe",
-        action="store_true",
-        help="skip ffprobe even if it is installed",
-    )
-    parser.add_argument(
-        "--verbose",
-        action="store_true",
-        help="enable debug logging",
-    )
+    parser.add_argument("--write", action="store_true", help="write metadata changes back to files")
+    parser.add_argument("--outputCsv", default="mp4_match_prompt_audit.csv", help="CSV report path")
+    parser.add_argument("--verbose", action="store_true", help="enable debug logging")
     return parser.parse_args(argv)
 
 
-def writeCsv(outputPath: Path, audits: list[FileAudit]) -> None:
+def iterMediaFiles(inputRoot: Path) -> Iterable[Path]:
+    for filePath in sorted(inputRoot.rglob("*")):
+        if filePath.is_file() and filePath.suffix.lower() in SUPPORTED_SUFFIXES:
+            yield filePath
+
+
+def determineSeasonInfo(filePath: Path, inputRoot: Path) -> SeasonInfo | None:
+    try:
+        relativePath = filePath.relative_to(inputRoot)
+    except ValueError:
+        relativePath = filePath
+
+    if not relativePath.parts:
+        return None
+
+    folderName = relativePath.parts[0]
+    if not re.fullmatch(r"\d{4}", folderName):
+        return None
+
+    startYear = int(folderName)
+    endYear = startYear + 1
+    return SeasonInfo(
+        seasonKey=startYear,
+        seasonLabel=f"{startYear}/{str(endYear)[-2:]}",
+        seasonStartYear=startYear,
+        seasonEndYear=endYear,
+    )
+
+
+def buildSeasonEpisodes(inputRoot: Path) -> dict[Path, int]:
+    seasonBuckets: dict[str, list[Path]] = {}
+    for filePath in iterMediaFiles(inputRoot):
+        try:
+            relativePath = filePath.relative_to(inputRoot)
+            seasonKey = relativePath.parts[0]
+        except Exception:
+            seasonKey = "unknown"
+        seasonBuckets.setdefault(seasonKey, []).append(filePath)
+
+    result: dict[Path, int] = {}
+    for _, files in seasonBuckets.items():
+        for index, filePath in enumerate(sorted(files), start=1):
+            result[filePath] = index
+    return result
+
+
+def getDefaultText(tags: dict[str, object], fieldName: str) -> str | None:
+    value = tags.get(fieldName)
+    if value is None:
+        return None
+    if isinstance(value, list):
+        return " | ".join(str(item) for item in value)
+    return str(value)
+
+
+def promptForFile(
+    filePath: Path,
+    inputRoot: Path,
+    episodeMap: dict[Path, int],
+    tagHelper: Mp4TagHelper,
+    parser: MatchParser,
+    prompter: InteractivePrompter,
+    writeChanges: bool,
+) -> dict[str, object]:
+    tags = tagHelper.readTags(filePath)
+    seasonInfo = determineSeasonInfo(filePath, inputRoot)
+    episode = episodeMap.get(filePath)
+
+    defaultTitle = getDefaultText(tags, "title")
+    defaultComment = getDefaultText(tags, "comment")
+
+    LOGGER.info("")
+    LOGGER.info("...file: %s", filePath)
+    if seasonInfo:
+        LOGGER.info("...season: %s", seasonInfo.seasonLabel)
+    if episode is not None:
+        LOGGER.info("...episode: %s", episode)
+
+    title = prompter.prompt("title", defaultTitle, filePath=filePath)
+    comment = prompter.prompt("score/comment", defaultComment, filePath=filePath)
+
+    if title is None:
+        title = defaultTitle
+    if comment is None:
+        comment = defaultComment
+
+    homeTeam, awayTeam = parser.parseTitle(title)
+
+    # enforce canonical title format
+    if homeTeam and awayTeam:
+        title = f"{homeTeam} vs. {awayTeam}"
+    homeScore, awayScore = parser.parseScore(comment)
+    winner = parser.determineWinner(homeTeam, awayTeam, homeScore, awayScore)
+
+    valuesToWrite: dict[str, object] = {
+        "artist": "Gloucester-Hartpury",  # fixed per user rule
+        "title": title or "",
+        "comment": comment or "",
+        "season": seasonInfo.seasonKey if seasonInfo else "",
+        "episode": episode or "",
+        "seasonLabel": seasonInfo.seasonLabel if seasonInfo else "",
+        "seasonStartYear": seasonInfo.seasonStartYear if seasonInfo else "",
+        "seasonEndYear": seasonInfo.seasonEndYear if seasonInfo else "",
+        "homeTeam": homeTeam or "",
+        "awayTeam": awayTeam or "",
+        "homeScore": homeScore if homeScore is not None else "",
+        "awayScore": awayScore if awayScore is not None else "",
+        "winner": winner or "",
+    }
+
+    if writeChanges:
+        tagHelper.writeTags(filePath, valuesToWrite)
+        LOGGER.info("...updated tags")
+    else:
+        LOGGER.info("...dry run values prepared")
+
+    return {
+        "filePath": str(filePath),
+        "seasonKey": seasonInfo.seasonKey if seasonInfo else "",
+        "seasonLabel": seasonInfo.seasonLabel if seasonInfo else "",
+        "episode": episode or "",
+        "title": title or "",
+        "comment": comment or "",
+        "homeTeam": homeTeam or "",
+        "awayTeam": awayTeam or "",
+        "homeScore": homeScore if homeScore is not None else "",
+        "awayScore": awayScore if awayScore is not None else "",
+        "winner": winner or "",
+        "writeMode": "write" if writeChanges else "dry-run",
+    }
+
+
+def writeCsv(outputPath: Path, rows: list[dict[str, object]]) -> None:
     fieldNames = [
         "filePath",
-        "fileName",
-        "status",
-        "issueCount",
-        "parsePattern",
-        "matchDate",
+        "seasonKey",
+        "seasonLabel",
+        "episode",
+        "title",
+        "comment",
         "homeTeam",
         "awayTeam",
         "homeScore",
         "awayScore",
         "winner",
-        "tagTitle",
-        "tagDate",
-        "tagHomeTeam",
-        "tagAwayTeam",
-        "tagHomeScore",
-        "tagAwayScore",
-        "tagWinner",
-        "issueSummary",
+        "writeMode",
     ]
 
     with outputPath.open("w", newline="", encoding="utf-8") as handle:
         writer = csv.DictWriter(handle, fieldnames=fieldNames)
         writer.writeheader()
-        for audit in audits:
-            writer.writerow(
-                {
-                    "filePath": audit.filePath,
-                    "fileName": audit.fileName,
-                    "status": audit.status,
-                    "issueCount": audit.issueCount,
-                    "parsePattern": audit.filenameData.parsePattern,
-                    "matchDate": audit.filenameData.matchDate,
-                    "homeTeam": audit.filenameData.homeTeam,
-                    "awayTeam": audit.filenameData.awayTeam,
-                    "homeScore": audit.filenameData.homeScore,
-                    "awayScore": audit.filenameData.awayScore,
-                    "winner": audit.filenameData.winner,
-                    "tagTitle": audit.tags.get("title"),
-                    "tagDate": audit.tags.get("date"),
-                    "tagHomeTeam": audit.tags.get("homeTeam"),
-                    "tagAwayTeam": audit.tags.get("awayTeam"),
-                    "tagHomeScore": audit.tags.get("homeScore"),
-                    "tagAwayScore": audit.tags.get("awayScore"),
-                    "tagWinner": audit.tags.get("winner"),
-                    "issueSummary": " | ".join(issue.message for issue in audit.issues),
-                }
-            )
-
-
-def writeJson(outputPath: Path, audits: list[FileAudit], summary: Summary) -> None:
-    payload = {
-        "generatedUtc": datetime.now(tz=timezone.utc).isoformat(),
-        "summary": asdict(summary),
-        "files": [
-            {
-                **asdict(audit),
-                "status": audit.status,
-                "issueCount": audit.issueCount,
-            }
-            for audit in audits
-        ],
-    }
-
-    with outputPath.open("w", encoding="utf-8") as handle:
-        json.dump(payload, handle, indent=2, ensure_ascii=False)
+        writer.writerows(rows)
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -586,30 +439,39 @@ def main(argv: list[str] | None = None) -> int:
     configureLogging(args.verbose)
 
     inputRoot = Path(args.inputRoot).expanduser().resolve()
+    if not inputRoot.exists() or not inputRoot.is_dir():
+        LOGGER.error("Input folder is invalid: %s", inputRoot)
+        return 2
+
+    tagHelper = Mp4TagHelper()
+    parser = MatchParser()
+    prompter = InteractivePrompter()
+    episodeMap = buildSeasonEpisodes(inputRoot)
+
+    rows: list[dict[str, object]] = []
+    try:
+        for filePath in iterMediaFiles(inputRoot):
+            rows.append(
+            promptForFile(
+                filePath=filePath,
+                inputRoot=inputRoot,
+                episodeMap=episodeMap,
+                tagHelper=tagHelper,
+                parser=parser,
+                prompter=prompter,
+                writeChanges=args.write,
+            )
+        )
+    except UserQuitRequested:
+        LOGGER.info("...user requested quit")
+
     outputCsv = Path(args.outputCsv).expanduser().resolve()
-    outputJson = Path(args.outputJson).expanduser().resolve()
+    writeCsv(outputCsv, rows)
 
-    if not inputRoot.exists():
-        LOGGER.error("Input folder does not exist: %s", inputRoot)
-        return 2
-
-    if not inputRoot.is_dir():
-        LOGGER.error("Input path is not a directory: %s", inputRoot)
-        return 2
-
-    engine = AuditEngine(includeFfprobe=not args.noFfprobe)
-    audits, summary = engine.auditFiles(inputRoot)
-
-    writeCsv(outputCsv, audits)
-    writeJson(outputJson, audits, summary)
-
-    LOGGER.info("...scanned files: %s", summary.scannedFiles)
-    LOGGER.info("...parsed filenames: %s", summary.parsedFilenames)
-    LOGGER.info("...files with tags: %s", summary.filesWithTags)
-    LOGGER.info("...files with issues: %s", summary.filesWithIssues)
+    LOGGER.info("")
+    LOGGER.info("...files processed: %s", len(rows))
     LOGGER.info("...csv report: %s", outputCsv)
-    LOGGER.info("...json report: %s", outputJson)
-
+    LOGGER.info("...mode: %s", "write" if args.write else "dry-run")
     return 0
 
 

--- a/rugbyAudit.py
+++ b/rugbyAudit.py
@@ -108,6 +108,23 @@ class SeasonInfo:
 
 
 @dataclass
+class FileContext:
+    """Context shown in the curses info panel while picking team names.
+
+    All fields are optional so the panel degrades gracefully when info
+    is not yet available (e.g. picking the home team before the away
+    team is known).
+    """
+
+    filePath: Path | None = None
+    seasonLabel: str | None = None
+    episode: int | None = None
+    existingTitle: str | None = None
+    existingScore: str | None = None
+    homeTeam: str | None = None
+
+
+@dataclass
 class MatchInfo:
     title: str | None
     comment: str | None
@@ -302,11 +319,20 @@ class TeamPicker:
 
     GLOUCESTER = "Gloucester-Hartpury"
 
-    def pick(self, label: str, knownTeams: list[str]) -> str | None:
+    def pick(
+        self,
+        label: str,
+        knownTeams: list[str],
+        context: FileContext | None = None,
+    ) -> str | None:
         """Return a team name chosen interactively.
 
         Tries a full-screen curses picker first.  Falls back to a numbered
         plain-text list when curses is unavailable (e.g. no TTY).
+
+        *context* is displayed in an info panel at the top of the curses
+        window showing the current file, season, episode, existing title,
+        score, and already-chosen home team.
 
         - Raises *UserQuitRequested* if the user presses ``q``.
         - Returns ``None`` if the user presses Escape (skip / leave blank).
@@ -314,18 +340,24 @@ class TeamPicker:
           subsequent calls benefit from it immediately.
         """
         try:
-            return curses.wrapper(self._cursesPick, label, knownTeams)
+            return curses.wrapper(self._cursesPick, label, knownTeams, context)
         except UserQuitRequested:
             raise
         except Exception as exc:
             logger.debug("...curses picker unavailable (%s), using text fallback", exc)
-            return self._fallbackPick(label, knownTeams)
+            return self._fallbackPick(label, knownTeams, context)
 
     # ------------------------------------------------------------------
     # Curses implementation
     # ------------------------------------------------------------------
 
-    def _cursesPick(self, stdscr, label: str, knownTeams: list[str]) -> str | None:
+    def _cursesPick(
+        self,
+        stdscr,
+        label: str,
+        knownTeams: list[str],
+        context: FileContext | None,
+    ) -> str | None:
 
         curses.curs_set(0)
         try:
@@ -348,12 +380,26 @@ class TeamPicker:
             stdscr.erase()
             height, width = stdscr.getmaxyx()
 
-            # Header and filter bar
-            self._addstrSafe(stdscr, 0, 0, f"{label}:", width)
-            self._addstrSafe(stdscr, 1, 0, f"  Filter: {filterText}", width)
-            self._addstrSafe(stdscr, 2, 0, "-" * (width - 1), width)
+            # ----------------------------------------------------------
+            # Info panel
+            # ----------------------------------------------------------
+            panelLines = self._buildInfoLines(context, width)
+            for row, line in enumerate(panelLines):
+                self._addstrSafe(stdscr, row, 0, line, width)
+            panelHeight = len(panelLines)
 
-            listTop = 3
+            # Separator after panel
+            sepAfterPanel = panelHeight
+            self._addstrSafe(stdscr, sepAfterPanel, 0, "-" * (width - 1), width)
+
+            # Label and filter bar
+            labelRow = sepAfterPanel + 1
+            filterRow = labelRow + 1
+            self._addstrSafe(stdscr, labelRow, 0, f"{label}:", width)
+            self._addstrSafe(stdscr, filterRow, 0, f"  Filter: {filterText}", width)
+            self._addstrSafe(stdscr, filterRow + 1, 0, "-" * (width - 1), width)
+
+            listTop = filterRow + 2
             statusRows = 2
             listHeight = max(1, height - listTop - statusRows)
 
@@ -434,6 +480,41 @@ class TeamPicker:
                 selected = 0
 
     @staticmethod
+    def _buildInfoLines(context: FileContext | None, width: int) -> list[str]:
+        """Return a list of fixed-width strings for the info panel.
+
+        Always returns at least one line so the panel separator is visible.
+        Each field is shown only when it contains useful data.
+        """
+        if context is None:
+            return [" (no file context)"]
+
+        lines: list[str] = []
+
+        if context.filePath is not None:
+            fileName = context.filePath.name
+            lines.append(f" File   : {fileName}"[: width - 1])
+
+        parts: list[str] = []
+        if context.seasonLabel:
+            parts.append(f"Season: {context.seasonLabel}")
+        if context.episode is not None:
+            parts.append(f"Ep: {context.episode}")
+        if parts:
+            lines.append(f" {('   '.join(parts))}"[: width - 1])
+
+        if context.existingTitle:
+            lines.append(f" Title  : {context.existingTitle}"[: width - 1])
+
+        score = context.existingScore or "(none)"
+        lines.append(f" Score  : {score}"[: width - 1])
+
+        if context.homeTeam:
+            lines.append(f" Home   : {context.homeTeam}"[: width - 1])
+
+        return lines if lines else [" (no file context)"]
+
+    @staticmethod
     def _addstrSafe(stdscr, y: int, x: int, text: str, width: int) -> None:
         """Write *text* at (*y*, *x*) clipped to *width*, ignoring boundary errors."""
         try:
@@ -452,8 +533,14 @@ class TeamPicker:
     # Plain-text fallback
     # ------------------------------------------------------------------
 
-    def _fallbackPick(self, label: str, knownTeams: list[str]) -> str | None:
+    def _fallbackPick(
+        self, label: str, knownTeams: list[str], context: FileContext | None = None
+    ) -> str | None:
         """Numbered plain-text list used when curses is unavailable."""
+        if context is not None:
+            infoLines = self._buildInfoLines(context, width=72)
+            print("\n" + "\n".join(infoLines))
+
         if knownTeams:
             print(f"\n{label}:")
             for i, team in enumerate(knownTeams, start=1):
@@ -611,8 +698,23 @@ def promptForFile(
         title = defaultTitle
         comment = defaultComment
     else:
-        homeTeam = teamPicker.pick("Home team", knownTeams)
-        awayTeam = teamPicker.pick("Away team", knownTeams)
+        baseContext = FileContext(
+            filePath=filePath,
+            seasonLabel=seasonInfo.seasonLabel if seasonInfo else None,
+            episode=episode,
+            existingTitle=defaultTitle,
+            existingScore=defaultComment,
+        )
+        homeTeam = teamPicker.pick("Home team", knownTeams, context=baseContext)
+        awayContext = FileContext(
+            filePath=filePath,
+            seasonLabel=seasonInfo.seasonLabel if seasonInfo else None,
+            episode=episode,
+            existingTitle=defaultTitle,
+            existingScore=defaultComment,
+            homeTeam=homeTeam,
+        )
+        awayTeam = teamPicker.pick("Away team", knownTeams, context=awayContext)
 
         title = None
         if homeTeam and awayTeam:

--- a/rugbyAudit.py
+++ b/rugbyAudit.py
@@ -324,6 +324,7 @@ class TeamPicker:
         label: str,
         knownTeams: list[str],
         context: FileContext | None = None,
+        default: str | None = None,
     ) -> str | None:
         """Return a team name chosen interactively.
 
@@ -334,18 +335,21 @@ class TeamPicker:
         window showing the current file, season, episode, existing title,
         score, and already-chosen home team.
 
+        *default* pre-positions the cursor on the matching entry so the user
+        can accept it immediately by pressing Enter.
+
         - Raises *UserQuitRequested* if the user presses ``q``.
         - Returns ``None`` if the user presses Escape (skip / leave blank).
         - Appends any new name to *knownTeams* (sorted in place) so that
           subsequent calls benefit from it immediately.
         """
         try:
-            return curses.wrapper(self._cursesPick, label, knownTeams, context)
+            return curses.wrapper(self._cursesPick, label, knownTeams, context, default)
         except UserQuitRequested:
             raise
         except Exception as exc:
             logger.debug("...curses picker unavailable (%s), using text fallback", exc)
-            return self._fallbackPick(label, knownTeams, context)
+            return self._fallbackPick(label, knownTeams, context, default)
 
     # ------------------------------------------------------------------
     # Curses implementation
@@ -357,6 +361,7 @@ class TeamPicker:
         label: str,
         knownTeams: list[str],
         context: FileContext | None,
+        default: str | None,
     ) -> str | None:
 
         curses.curs_set(0)
@@ -365,7 +370,16 @@ class TeamPicker:
         except curses.error:
             pass
 
-        selected = 0
+        # Pre-position the cursor on the default team when one is supplied.
+        if default:
+            lower = default.casefold()
+            defaultIdx = next(
+                (i for i, t in enumerate(knownTeams) if t.casefold() == lower), 0
+            )
+        else:
+            defaultIdx = 0
+
+        selected = defaultIdx
         filterText = ""
 
         while True:
@@ -534,7 +548,11 @@ class TeamPicker:
     # ------------------------------------------------------------------
 
     def _fallbackPick(
-        self, label: str, knownTeams: list[str], context: FileContext | None = None
+        self,
+        label: str,
+        knownTeams: list[str],
+        context: FileContext | None = None,
+        default: str | None = None,
     ) -> str | None:
         """Numbered plain-text list used when curses is unavailable."""
         if context is not None:
@@ -544,13 +562,18 @@ class TeamPicker:
         if knownTeams:
             print(f"\n{label}:")
             for i, team in enumerate(knownTeams, start=1):
-                print(f"  {i:2}. {team}")
+                marker = " *" if default and team.casefold() == default.casefold() else ""
+                print(f"  {i:2}. {team}{marker}")
             print()
 
+        defaultHint = f" Enter={default}" if default else " Enter=skip"
         while True:
-            prompt = f"{label} [number, new name, g=Gloucester, q=quit, Enter=skip]: "
+            prompt = f"{label} [number, new name, g=Gloucester, q=quit,{defaultHint}]: "
             response = input(prompt).strip()
             if not response:
+                if default:
+                    self._addToKnownTeams(default, knownTeams)
+                    return default
                 return None
             if response.lower() == "q":
                 raise UserQuitRequested()
@@ -724,6 +747,14 @@ def promptForFile(
         title = defaultTitle
         comment = defaultComment
     else:
+        # Derive default team names from the filename stem so the picker can
+        # pre-position the cursor and the user can simply press Enter.
+        fileHomeTeam, fileAwayTeam = parser.parseTitle(filePath.stem)
+        if fileHomeTeam:
+            fileHomeTeam = _cleanTeamName(fileHomeTeam)
+        if fileAwayTeam:
+            fileAwayTeam = _cleanTeamName(fileAwayTeam)
+
         baseContext = FileContext(
             filePath=filePath,
             seasonLabel=seasonInfo.seasonLabel if seasonInfo else None,
@@ -731,7 +762,9 @@ def promptForFile(
             existingTitle=defaultTitle,
             existingScore=defaultComment,
         )
-        homeTeam = teamPicker.pick("Home team", knownTeams, context=baseContext)
+        homeTeam = teamPicker.pick(
+            "Home team", knownTeams, context=baseContext, default=fileHomeTeam
+        )
         awayContext = FileContext(
             filePath=filePath,
             seasonLabel=seasonInfo.seasonLabel if seasonInfo else None,
@@ -740,7 +773,9 @@ def promptForFile(
             existingScore=defaultComment,
             homeTeam=homeTeam,
         )
-        awayTeam = teamPicker.pick("Away team", knownTeams, context=awayContext)
+        awayTeam = teamPicker.pick(
+            "Away team", knownTeams, context=awayContext, default=fileAwayTeam
+        )
 
         title = None
         if homeTeam and awayTeam:

--- a/rugbyAudit.py
+++ b/rugbyAudit.py
@@ -11,7 +11,16 @@ Purpose
 - optionally write updated metadata back to files
 - write a CSV audit report
 
-User interaction rule
+User interaction rule (team picker)
+- up/down arrows (or j/k when not filtering) navigate the team list
+- typing any character filters the list to matching team names
+- pressing Enter selects the highlighted team, or submits the typed text as a new name
+- pressing Escape skips the field (leaves it blank)
+- pressing g (when not filtering) instantly selects Gloucester-Hartpury
+- pressing q (when not filtering) quits the session
+- pressing Backspace removes the last filter character
+
+User interaction rule (score/comment prompt)
 - pressing Enter accepts the shown default
 - entering q quits the session
 - entering p plays the current video so you can inspect it
@@ -30,6 +39,9 @@ Notes
   example: folder 2024 => seasonLabel 2024/25
 - episode is assigned by ordering matches within a season folder
   after sorting by file path
+- the team list is built automatically from existing title tags before
+  the interactive loop starts; new names entered during the session are
+  added to the list immediately
 
 Dependencies
     pip install mutagen
@@ -39,6 +51,7 @@ from __future__ import annotations
 
 import argparse
 import csv
+import curses
 import logging
 import re
 import shutil
@@ -278,6 +291,195 @@ class UserQuitRequested(Exception):
     """Raised when the user chooses to quit the interactive session."""
 
 
+class TeamPicker:
+    """Curses-based interactive team picker with a plain-text numbered fallback.
+
+    Usage::
+
+        picker = TeamPicker()
+        team = picker.pick("Home team", knownTeams)
+    """
+
+    GLOUCESTER = "Gloucester-Hartpury"
+
+    def pick(self, label: str, knownTeams: list[str]) -> str | None:
+        """Return a team name chosen interactively.
+
+        Tries a full-screen curses picker first.  Falls back to a numbered
+        plain-text list when curses is unavailable (e.g. no TTY).
+
+        - Raises *UserQuitRequested* if the user presses ``q``.
+        - Returns ``None`` if the user presses Escape (skip / leave blank).
+        - Appends any new name to *knownTeams* (sorted in place) so that
+          subsequent calls benefit from it immediately.
+        """
+        try:
+            return curses.wrapper(self._cursesPick, label, knownTeams)
+        except UserQuitRequested:
+            raise
+        except Exception as exc:
+            logger.debug("...curses picker unavailable (%s), using text fallback", exc)
+            return self._fallbackPick(label, knownTeams)
+
+    # ------------------------------------------------------------------
+    # Curses implementation
+    # ------------------------------------------------------------------
+
+    def _cursesPick(self, stdscr, label: str, knownTeams: list[str]) -> str | None:
+
+        curses.curs_set(0)
+        try:
+            curses.use_default_colors()
+        except curses.error:
+            pass
+
+        selected = 0
+        filterText = ""
+
+        while True:
+            if filterText:
+                filtered = [t for t in knownTeams if filterText.lower() in t.lower()]
+            else:
+                filtered = list(knownTeams)
+
+            if filtered:
+                selected = max(0, min(selected, len(filtered) - 1))
+
+            stdscr.erase()
+            height, width = stdscr.getmaxyx()
+
+            # Header and filter bar
+            self._addstrSafe(stdscr, 0, 0, f"{label}:", width)
+            self._addstrSafe(stdscr, 1, 0, f"  Filter: {filterText}", width)
+            self._addstrSafe(stdscr, 2, 0, "-" * (width - 1), width)
+
+            listTop = 3
+            statusRows = 2
+            listHeight = max(1, height - listTop - statusRows)
+
+            # Team list
+            if filtered:
+                scrollOffset = max(0, selected - listHeight // 2)
+                scrollOffset = min(scrollOffset, max(0, len(filtered) - listHeight))
+                for i in range(listHeight):
+                    idx = scrollOffset + i
+                    if idx >= len(filtered):
+                        break
+                    rowY = listTop + i
+                    if rowY >= height - statusRows:
+                        break
+                    text = f"  {filtered[idx]}"
+                    if idx == selected:
+                        stdscr.attron(curses.A_REVERSE)
+                        self._addstrSafe(stdscr, rowY, 0, text, width)
+                        stdscr.attroff(curses.A_REVERSE)
+                    else:
+                        self._addstrSafe(stdscr, rowY, 0, text, width)
+            else:
+                if filterText:
+                    msg = f"  (no matches - press Enter to use '{filterText}')"
+                else:
+                    msg = "  (no teams known yet - type a name and press Enter)"
+                self._addstrSafe(stdscr, listTop, 0, msg, width)
+
+            # Status bar
+            sepRow = height - statusRows
+            if sepRow >= 0:
+                self._addstrSafe(stdscr, sepRow, 0, "-" * (width - 1), width)
+            if filterText:
+                hint = "up/down navigate  Enter=select/new  Backspace=clear  Esc=skip"
+            else:
+                hint = "up/down/jk navigate  g=Gloucester  Esc=skip  q=quit  type to filter"
+            self._addstrSafe(stdscr, height - 1, 0, hint, width)
+
+            stdscr.refresh()
+            key = stdscr.getch()
+
+            # Universal navigation
+            if key == curses.KEY_UP and filtered:
+                selected = max(0, selected - 1)
+            elif key == curses.KEY_DOWN and filtered:
+                selected = min(len(filtered) - 1, selected + 1)
+            # Enter: select highlighted, submit typed text, or skip
+            elif key in (curses.KEY_ENTER, 10, 13):
+                if filtered:
+                    result = filtered[selected]
+                elif filterText:
+                    result = filterText
+                else:
+                    result = None
+                if result:
+                    self._addToKnownTeams(result, knownTeams)
+                return result
+            # Backspace removes last filter character
+            elif key in (curses.KEY_BACKSPACE, 127, 8):
+                filterText = filterText[:-1]
+                selected = 0
+            # Escape skips the field
+            elif key == 27:
+                return None
+            # Browse-mode shortcuts (only when no filter text is active)
+            elif key == ord("g") and not filterText:
+                self._addToKnownTeams(self.GLOUCESTER, knownTeams)
+                return self.GLOUCESTER
+            elif key == ord("q") and not filterText:
+                raise UserQuitRequested()
+            elif key == ord("j") and not filterText and filtered:
+                selected = min(len(filtered) - 1, selected + 1)
+            elif key == ord("k") and not filterText and filtered:
+                selected = max(0, selected - 1)
+            # Any printable character extends the filter
+            elif 32 <= key <= 126:
+                filterText += chr(key)
+                selected = 0
+
+    @staticmethod
+    def _addstrSafe(stdscr, y: int, x: int, text: str, width: int) -> None:
+        """Write *text* at (*y*, *x*) clipped to *width*, ignoring boundary errors."""
+        try:
+            stdscr.addstr(y, x, text[: max(0, width - x)])
+        except curses.error:
+            pass
+
+    @staticmethod
+    def _addToKnownTeams(name: str, knownTeams: list[str]) -> None:
+        """Add *name* to *knownTeams* if not already present, keeping it sorted."""
+        if name not in knownTeams:
+            knownTeams.append(name)
+            knownTeams.sort(key=str.casefold)
+
+    # ------------------------------------------------------------------
+    # Plain-text fallback
+    # ------------------------------------------------------------------
+
+    def _fallbackPick(self, label: str, knownTeams: list[str]) -> str | None:
+        """Numbered plain-text list used when curses is unavailable."""
+        if knownTeams:
+            print(f"\n{label}:")
+            for i, team in enumerate(knownTeams, start=1):
+                print(f"  {i:2}. {team}")
+            print()
+
+        while True:
+            prompt = f"{label} [number, new name, g=Gloucester, q=quit, Enter=skip]: "
+            response = input(prompt).strip()
+            if not response:
+                return None
+            if response.lower() == "q":
+                raise UserQuitRequested()
+            if response.lower() == "g":
+                self._addToKnownTeams(self.GLOUCESTER, knownTeams)
+                return self.GLOUCESTER
+            if response.isdigit():
+                idx = int(response) - 1
+                if 0 <= idx < len(knownTeams):
+                    return knownTeams[idx]
+                print(f"  ...invalid number, choose 1-{len(knownTeams)}")
+                continue
+            self._addToKnownTeams(response, knownTeams)
+            return response
+
+
 def configureLogging(verbose: bool) -> None:
     logging.basicConfig(
         level=logging.DEBUG if verbose else logging.INFO, format="%(message)s"
@@ -358,6 +560,26 @@ def getDefaultText(tags: dict[str, object], fieldName: str) -> str | None:
     return str(value)
 
 
+def buildKnownTeams(
+    inputRoot: Path, tagHelper: Mp4TagHelper, parser: MatchParser
+) -> list[str]:
+    """Pre-scan media files and extract unique team names from existing title tags.
+
+    Returns a case-insensitively sorted list of distinct team names found in
+    the ``title`` atoms of all media files under *inputRoot*.
+    """
+    teamSet: set[str] = set()
+    for filePath in iterMediaFiles(inputRoot):
+        tags = tagHelper.readTags(filePath)
+        title = getDefaultText(tags, "title")
+        homeTeam, awayTeam = parser.parseTitle(title)
+        if homeTeam:
+            teamSet.add(homeTeam.strip())
+        if awayTeam:
+            teamSet.add(awayTeam.strip())
+    return sorted(teamSet, key=str.casefold)
+
+
 def promptForFile(
     filePath: Path,
     inputRoot: Path,
@@ -365,6 +587,8 @@ def promptForFile(
     tagHelper: Mp4TagHelper,
     parser: MatchParser,
     prompter: InteractivePrompter,
+    teamPicker: TeamPicker,
+    knownTeams: list[str],
     writeChanges: bool,
 ) -> dict[str, object]:
     tags = tagHelper.readTags(filePath)
@@ -387,13 +611,8 @@ def promptForFile(
         title = defaultTitle
         comment = defaultComment
     else:
-        homeTeam = prompter.prompt("home team", None, filePath=filePath)
-        if homeTeam == "g":
-            homeTeam = "Gloucester-Hartpury"
-
-        awayTeam = prompter.prompt("away team", None, filePath=filePath)
-        if awayTeam == "g":
-            awayTeam = "Gloucester-Hartpury"
+        homeTeam = teamPicker.pick("Home team", knownTeams)
+        awayTeam = teamPicker.pick("Away team", knownTeams)
 
         title = None
         if homeTeam and awayTeam:
@@ -487,7 +706,12 @@ def main(argv: list[str] | None = None) -> int:
     tagHelper = Mp4TagHelper()
     parser = MatchParser()
     prompter = InteractivePrompter()
+    teamPicker = TeamPicker()
     episodeMap = buildSeasonEpisodes(inputRoot)
+
+    logger.info("...building known teams from existing tags")
+    knownTeams = buildKnownTeams(inputRoot, tagHelper, parser)
+    logger.info("...found %d known team(s)", len(knownTeams))
 
     rows: list[dict[str, object]] = []
     try:
@@ -500,6 +724,8 @@ def main(argv: list[str] | None = None) -> int:
                     tagHelper=tagHelper,
                     parser=parser,
                     prompter=prompter,
+                    teamPicker=teamPicker,
+                    knownTeams=knownTeams,
                     writeChanges=not dryRun,
                 )
             )

--- a/rugbyAudit.py
+++ b/rugbyAudit.py
@@ -50,7 +50,6 @@ from typing import Iterable
 
 from mutagen.mp4 import MP4, MP4FreeForm  # type: ignore
 
-
 logger = logging.getLogger("mp4MatchAudit")
 SUPPORTED_SUFFIXES = {".mp4", ".m4v", ".mov"}
 FREEFORM_PREFIX = "----:com.apple.iTunes:"
@@ -109,7 +108,10 @@ class MatchInfo:
 
 
 class Mp4TagHelper:
+    """Read and write MP4/M4V metadata tags using mutagen."""
+
     def readTags(self, filePath: Path) -> dict[str, object]:
+        """Return a normalised dict of tag field-name → value for *filePath*."""
         try:
             mp4File = MP4(str(filePath))
         except Exception as exc:
@@ -126,6 +128,7 @@ class Mp4TagHelper:
         return result
 
     def writeTags(self, filePath: Path, values: dict[str, object]) -> None:
+        """Write *values* as MP4 tags to *filePath*, skipping blank/None entries."""
         mp4File = MP4(str(filePath))
         if mp4File.tags is None:
             mp4File.add_tags()
@@ -146,7 +149,7 @@ class Mp4TagHelper:
     @staticmethod
     def _mapFreeformFieldName(key: str) -> str:
         if key.startswith(FREEFORM_PREFIX):
-            return key[len(FREEFORM_PREFIX):]
+            return key[len(FREEFORM_PREFIX) :]
         return key
 
     def _normaliseTagValue(self, value: object) -> object:
@@ -173,7 +176,11 @@ class Mp4TagHelper:
 
 
 class MatchParser:
-    TITLE_PATTERN = re.compile(r"^(?P<home>.+?)\s+(?:vs\.?|v)\s+(?P<away>.+?)$", re.IGNORECASE)
+    """Parse match titles and scores from free-text strings."""
+
+    TITLE_PATTERN = re.compile(
+        r"^(?P<home>.+?)\s+(?:vs\.?|v)\s+(?P<away>.+?)$", re.IGNORECASE
+    )
     SCORE_PATTERN = re.compile(r"^(?P<home>\d{1,3})\s*[-:]\s*(?P<away>\d{1,3})$")
 
     def parseTitle(self, title: str | None) -> tuple[str | None, str | None]:
@@ -216,10 +223,14 @@ class MatchParser:
 
 
 class InteractivePrompter:
+    """Prompt the user for match metadata values and optionally play the video."""
+
     def __init__(self) -> None:
         self.playerPath = self._findPlayer()
 
-    def prompt(self, label: str, default: str | None = None, filePath: Path | None = None) -> str | None:
+    def prompt(
+        self, label: str, default: str | None = None, filePath: Path | None = None
+    ) -> str | None:
         while True:
             if default is None:
                 promptText = f"{label} [enter=blank, q=quit, p=play]: "
@@ -268,14 +279,26 @@ class UserQuitRequested(Exception):
 
 
 def configureLogging(verbose: bool) -> None:
-    logging.basicConfig(level=logging.DEBUG if verbose else logging.INFO, format="%(message)s")
+    logging.basicConfig(
+        level=logging.DEBUG if verbose else logging.INFO, format="%(message)s"
+    )
 
 
 def parseArgs(argv: list[str]) -> argparse.Namespace:
-    parser = argparse.ArgumentParser(description="Interactively audit and tag rugby match videos.")
-    parser.add_argument("inputRoot", help="root folder to scan")
-    parser.add_argument("--write", action="store_true", help="write metadata changes back to files")
-    parser.add_argument("--outputCsv", default="mp4_match_prompt_audit.csv", help="CSV report path")
+    """Parse command-line arguments."""
+    parser = argparse.ArgumentParser(
+        description="Interactively audit and tag rugby match videos."
+    )
+    parser.add_argument("--source", required=True, help="root folder to scan")
+    parser.add_argument(
+        "--confirm",
+        dest="confirm",
+        action="store_true",
+        help="execute changes — write metadata back to files (default is dry-run)",
+    )
+    parser.add_argument(
+        "--outputCsv", default="mp4_match_prompt_audit.csv", help="CSV report path"
+    )
     parser.add_argument("--verbose", action="store_true", help="enable debug logging")
     return parser.parse_args(argv)
 
@@ -454,8 +477,9 @@ def writeCsv(outputPath: Path, rows: list[dict[str, object]]) -> None:
 def main(argv: list[str] | None = None) -> int:
     args = parseArgs(argv or sys.argv[1:])
     configureLogging(args.verbose)
+    dryRun = not args.confirm
 
-    inputRoot = Path(args.inputRoot).expanduser().resolve()
+    inputRoot = Path(args.source).expanduser().resolve()
     if not inputRoot.exists() or not inputRoot.is_dir():
         logger.error("Input folder is invalid: %s", inputRoot)
         return 2
@@ -469,16 +493,16 @@ def main(argv: list[str] | None = None) -> int:
     try:
         for filePath in iterMediaFiles(inputRoot):
             rows.append(
-            promptForFile(
-                filePath=filePath,
-                inputRoot=inputRoot,
-                episodeMap=episodeMap,
-                tagHelper=tagHelper,
-                parser=parser,
-                prompter=prompter,
-                writeChanges=args.write,
+                promptForFile(
+                    filePath=filePath,
+                    inputRoot=inputRoot,
+                    episodeMap=episodeMap,
+                    tagHelper=tagHelper,
+                    parser=parser,
+                    prompter=prompter,
+                    writeChanges=not dryRun,
+                )
             )
-        )
     except UserQuitRequested:
         logger.info("...user requested quit")
 
@@ -488,7 +512,7 @@ def main(argv: list[str] | None = None) -> int:
     logger.info("")
     logger.info("...files processed: %s", len(rows))
     logger.info("...csv report: %s", outputCsv)
-    logger.info("...mode: %s", "write" if args.write else "dry-run")
+    logger.info("...mode: %s", "write" if not dryRun else "dry-run")
     return 0
 
 


### PR DESCRIPTION
- [x] Understand TeamPicker, _cursesPick, _fallbackPick, promptForFile
- [x] Add `default: str | None = None` to `TeamPicker.pick()` / `_cursesPick()` / `_fallbackPick()`
- [x] In `_cursesPick`: initialise `selected` to the index of `default` in `knownTeams` (0 if not found)
- [x] In `_fallbackPick`: mark default with `*` in list; bare Enter accepts it instead of skipping
- [x] In `promptForFile`: parse filename stem with `parser.parseTitle` + `_cleanTeamName` → `fileHomeTeam` / `fileAwayTeam`; pass as `default=` to each `pick()` call
- [x] All pre-positioning examples verified; 151 tests pass